### PR TITLE
Allow additionalProperties field set to False

### DIFF
--- a/jsonschema_markdown/converter/markdown.py
+++ b/jsonschema_markdown/converter/markdown.py
@@ -198,7 +198,7 @@ def _get_property_details(property_type: str, property_details: dict) -> tuple:
     elif "pattern" in property_details:
         pattern = property_details.get("pattern", "?")
         res_details = f"[`{pattern}`](https://regex101.com/?regex={urllib.parse.quote_plus(pattern)})"
-    elif "additionalProperties" in property_details:
+    elif "additionalProperties" in property_details and property_details["additionalProperties"]:
         title = property_details["additionalProperties"].get("title")
         _type = property_details["additionalProperties"].get("type")
         if title:

--- a/tests/schema-examples/simple.json
+++ b/tests/schema-examples/simple.json
@@ -16,6 +16,19 @@
       "description": "Age in years which must be equal to or greater than zero.",
       "type": "integer",
       "minimum": 0
+    },
+    "job": {
+      "description": "The person's job.",
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "salary": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
     }
   }
 }


### PR DESCRIPTION
`additionalProperties` set as False in a nested type seems to break with:

```
Traceback (most recent call last):
  File "/home/me/.cache/pypoetry/virtualenvs/jsonschema-markdown-RVVSjzJS-py3.11/bin/jsonschema-markdown", line 6, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/me/.cache/pypoetry/virtualenvs/jsonschema-markdown-RVVSjzJS-py3.11/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/me/.cache/pypoetry/virtualenvs/jsonschema-markdown-RVVSjzJS-py3.11/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/me/.cache/pypoetry/virtualenvs/jsonschema-markdown-RVVSjzJS-py3.11/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/me/.cache/pypoetry/virtualenvs/jsonschema-markdown-RVVSjzJS-py3.11/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/me/src/jsonschema-markdown/jsonschema_markdown/main.py", line 25, in cli
    markdown = jsonschema_markdown.generate(file_contents, footer=footer)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/me/src/jsonschema-markdown/jsonschema_markdown/converter/markdown.py", line 22, in generate
    markdown += _create_definition_table(_schema)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/me/src/jsonschema-markdown/jsonschema_markdown/converter/markdown.py", line 289, in _create_definition_table
    property_type, possible_values = _get_property_details(
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/me/src/jsonschema-markdown/jsonschema_markdown/converter/markdown.py", line 202, in _get_property_details
    title = property_details["additionalProperties"].get("title")
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'bool' object has no attribute 'get'
```

This PR fixes it by checking if it's False.

Using python 3.11 and poetry 1.5.1