### PR TITLE
feat: Add support to format examples as YAML or JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,5 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 junit/
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Options:
   --resolve / --no-resolve        [Experimental] Resolve $ref pointers.
                                   [default: no-resolve]
   --debug / --no-debug            Enable debug output.  [default: no-debug]
+  --examples-format [text|yaml|json]
+                                  Format of the examples in the output.
+                                  [default: text]
   --version                       Show the version and exit.
   --help                          Show this message and exit.
 
@@ -96,3 +99,80 @@ this project does not currently support all features, but it should support:
   - This project is still in early development, and the output may change in the future.
   - Custom definitions are expected to be in the same file as the schema that uses them,
     in the `definitions` or `$defs` parameter at the root of the document.
+  - Inline nested definitions are not represented in the output yet. See #18.
+
+---
+
+## Examples
+
+### Example 1 Input
+
+Given the following JSON Schema:
+```json
+{
+  "$id": "https://example.com/movie.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A representation of a movie",
+  "type": "object",
+  "required": ["title", "director", "releaseDate"],
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "director": {
+      "type": "string"
+    },
+    "releaseDate": {
+      "type": "string",
+      "format": "date"
+    },
+    "genre": {
+      "type": "string",
+      "enum": ["Action", "Comedy", "Drama", "Science Fiction"]
+    },
+    "duration": {
+      "type": "string"
+    },
+    "cast": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "additionalItems": false
+    }
+  }
+}
+```
+
+### Example 1 Ouput
+The following markdown will be generated:
+
+---
+
+# jsonschema-markdown
+
+A representation of a movie
+
+### Type: `object`
+
+| Property | Type | Required | Possible values | Deprecated | Default | Description | Examples |
+| -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- | -------- |
+| title | `string` | ✅ | string |  |  |  |  |
+| director | `string` | ✅ | string |  |  |  |  |
+| releaseDate | `string` | ✅ | Format: [`date`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  |  |  |
+| genre | `string` |  | `Action` `Comedy` `Drama` `Science Fiction` |  |  |  |  |
+| duration | `string` |  | string |  |  |  |  |
+| cast | `array` |  | string |  |  |  |  |
+
+
+---
+
+Markdown generated with [jsonschema-markdown](https://github.com/elisiariocouto/jsonschema-markdown).
+
+---
+
+### Example 2
+
+In [tests/model.py](tests/model.py) you can see a more complex example of a model that is exported as a JSON Schema.
+
+The output can be seen in [tests/model.md](tests/model.md).

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ this project does not currently support all features, but it should support:
   - Integers with minimum, maximum values and exclusives
   - Boolean values
   - Deprecated fields (using the `deprecated` option, additionaly searches for case-insensitive `deprecated` in the field description)
+  - Supports optional YAML and JSON formatting for examples
 
 ## Caveats
   - This project is still in early development, and the output may change in the future.

--- a/jsonschema_markdown/main.py
+++ b/jsonschema_markdown/main.py
@@ -41,8 +41,15 @@ import jsonschema_markdown
     show_default=True,
     help="Enable debug output.",
 )
+@click.option(
+    "--examples-format",
+    type=click.Choice(["text", "yaml", "json"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Format of the examples in the output.",
+)
 @click.version_option(package_name="jsonschema_markdown")
-def cli(filename, title, footer, empty_columns, resolve, debug):
+def cli(filename, title, footer, empty_columns, resolve, debug, examples_format):
     """
     Load FILENAME and output a markdown version.
 
@@ -56,6 +63,7 @@ def cli(filename, title, footer, empty_columns, resolve, debug):
         "replace_refs": resolve,
         "debug": debug,
         "hide_empty_columns": not empty_columns,
+        "examples_format": examples_format,
     }
 
     if title:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "jsonschema-markdown"
 license = "MIT"
-version = "0.3.12"
+version = "0.3.11"
 description = "Export a JSON Schema document to Markdown documentation."
 authors = ["Elisiário Couto <elisiario@couto.io>"]
 repository = "https://github.com/elisiariocouto/jsonschema-markdown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "jsonschema-markdown"
 license = "MIT"
-version = "0.3.11"
+version = "0.3.12"
 description = "Export a JSON Schema document to Markdown documentation."
 authors = ["Elisiário Couto <elisiario@couto.io>"]
 repository = "https://github.com/elisiariocouto/jsonschema-markdown"

--- a/tests/test_generate_examples_format.py
+++ b/tests/test_generate_examples_format.py
@@ -1,9 +1,10 @@
-from jsonschema_markdown.converter.markdown import _format_example
 import pytest
+
+from jsonschema_markdown.converter.markdown import _format_example
 
 
 @pytest.mark.parametrize(
-    "example, format_type, expected",
+    "example, format_type, expected_md",
     [
         ({"key": "value"}, "yaml", "```yaml\nkey: value\n\n```"),
         ("example string", "yaml", "```yaml\nexample string\n```"),
@@ -13,6 +14,6 @@ import pytest
         ({"key": "value"}, "invalid_format", "```\n{'key': 'value'}\n```"),
     ],
 )
-def test_generate_examples_format(example, format, expected_md):
-    formatted = _format_example(example, format)
+def test_generate_examples_format(example, format_type, expected_md):
+    formatted = _format_example(example, format_type)
     assert formatted == expected_md

--- a/tests/test_generate_examples_format.py
+++ b/tests/test_generate_examples_format.py
@@ -1,0 +1,18 @@
+from jsonschema_markdown.converter.markdown import _format_example
+import pytest
+
+
+@pytest.mark.parametrize(
+    "example, format_type, expected",
+    [
+        ({"key": "value"}, "yaml", "```yaml\nkey: value\n\n```"),
+        ("example string", "yaml", "```yaml\nexample string\n```"),
+        ({"key": "value"}, "json", '```json\n{\n  "key": "value"\n}\n```'),
+        ("example string", "json", "```json\nexample string\n```"),
+        ({"key": "value"}, "text", "```\n{'key': 'value'}\n```"),
+        ({"key": "value"}, "invalid_format", "```\n{'key': 'value'}\n```"),
+    ],
+)
+def test_generate_examples_format(example, format, expected_md):
+    formatted = _format_example(example, format)
+    assert formatted == expected_md


### PR DESCRIPTION
- Added option --examples-format allowing to format examples as yaml or json

<img width="723" alt="image" src="https://github.com/user-attachments/assets/93653498-8f28-4d93-8df2-9e8e153521cb">

And generated result is:

<img width="653" alt="image" src="https://github.com/user-attachments/assets/0f39e142-7fff-4ea1-9bd3-0e2a320a6fea">
