### PR TITLE
update default in test field

### DIFF
--- a/tests/model.py
+++ b/tests/model.py
@@ -79,7 +79,7 @@ class Engine(BaseModel):
     )
     liters: float = Field(
         description="The displacement of the engine in liters.",
-        gt=0,
+        gt=0.0,
     )
 
     model_config = ConfigDict(


### PR DESCRIPTION
Thanks for this tool!

This proposes an minor update to a test fixture to match the expected output against an unpinned `pydantic` (happens to be `2.11.4`).