### PR TITLE
Fix: None values handling in array type details

### DIFF
--- a/jsonschema_markdown/converter/markdown.py
+++ b/jsonschema_markdown/converter/markdown.py
@@ -449,14 +449,18 @@ def _handle_array_like_property(
     # Arrays should return the type as array
     # Other array-like properties should return the types of the nested oneOf, anyOf or allOf
     if return_type:
-        return return_type, array_separator[array_type].join(sorted(details))
+        return return_type, array_separator[array_type].join(
+            sorted(x for x in details if x is not None)
+        )
     else:
         # Dedeuplicate list of types, join them with null at the end if present
         types = sorted(set(types))
         if "`null`" in types:
             types.remove("`null`")
             types.append("`null`")
-        return " or ".join(types), array_separator[array_type].join(sorted(details))
+        return " or ".join(types), array_separator[array_type].join(
+            sorted(x for x in details if x is not None)
+        )
 
 
 def _get_property_details(


### PR DESCRIPTION
Filter out None values from details when joining.

This solves the case when you have the data:
```json
{
  "properties": {
    "list": {
      "description": "List",
      "items": {
        "anyOf": [
          {
            "required": ["A"]
          },
          {
            "required": ["B"]
          }
        ],
        "properties": {
          "A": {
            "type": "string"
          },
          "B": {
            "type": "string"
          }
        },
        "type": "object"
      },
      "minItems": 1,
      "type": "array"
    }
  },
  "title": "Example",
  "type": "object"
}
```
Which otherwise gives this error:
```
TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'
```

Here is one possible way to deal with the output:
```md
### Type: `object`

| Property | Type | Required | Possible values | Description |
| -------- | ---- | -------- | --------------- | ----------- |
| list | `array` |  | object | List |
| list[].A and/or list[].B | `string` |  | string |  |
```