### PR TITLE
Extract inline object definitions from combinators into $defs

### DIFF
--- a/jsonschema_markdown/converter/markdown.py
+++ b/jsonschema_markdown/converter/markdown.py
@@ -1,4 +1,5 @@
 import contextlib
+import copy
 import json
 import sys
 import urllib.parse
@@ -79,6 +80,95 @@ def _get_schema_header(
     return md
 
 
+def _extract_inline_defs(schema: dict) -> dict:
+    """
+    Walk the schema tree and extract inline object definitions from
+    anyOf/oneOf/allOf combinators into $defs, replacing them with $ref.
+
+    Returns a new schema dict (deep copy) with inline objects promoted to $defs.
+    """
+    schema = copy.deepcopy(schema)
+
+    defs_key = "definitions" if "definitions" in schema else "$defs"
+
+    if defs_key not in schema:
+        schema[defs_key] = {}
+
+    defs = schema[defs_key]
+    counter = [0]
+
+    def _make_ref(name: str) -> dict:
+        return {"$ref": f"#/{defs_key}/{name}"}
+
+    def _choose_name(obj: dict) -> str:
+        title = obj.get("title")
+        if not title:
+            counter[0] += 1
+            return f"InlineObject{counter[0]}"
+
+        name = title
+        if name in defs:
+            if defs[name] == obj:
+                return name
+            suffix = 2
+            while f"{title}_{suffix}" in defs:
+                suffix += 1
+            return f"{title}_{suffix}"
+        return name
+
+    def _is_extractable(entry: dict) -> bool:
+        if not isinstance(entry, dict) or "$ref" in entry:
+            return False
+        has_properties = bool(entry.get("properties"))
+        is_object = entry.get("type") == "object" or (
+            has_properties and "type" not in entry
+        )
+        return is_object and has_properties
+
+    def _process_combinator(parent: dict, combinator_key: str):
+        entries = parent[combinator_key]
+        for i, entry in enumerate(entries):
+            if not isinstance(entry, dict):
+                continue
+            _walk(entry)
+            if _is_extractable(entry):
+                name = _choose_name(entry)
+                if name not in defs:
+                    defs[name] = entry
+                entries[i] = _make_ref(name)
+
+    def _walk(node: dict):
+        if not isinstance(node, dict):
+            return
+
+        for _prop_name, prop_details in node.get("properties", {}).items():
+            if not isinstance(prop_details, dict):
+                continue
+
+            for combinator in ("anyOf", "oneOf", "allOf"):
+                if combinator in prop_details:
+                    _process_combinator(prop_details, combinator)
+
+            items = prop_details.get("items")
+            if isinstance(items, dict):
+                for combinator in ("anyOf", "oneOf", "allOf"):
+                    if combinator in items:
+                        _process_combinator(items, combinator)
+                _walk(items)
+
+            _walk(prop_details)
+
+    _walk(schema)
+
+    for def_name in list(defs.keys()):
+        _walk(defs[def_name])
+
+    if not defs:
+        del schema[defs_key]
+
+    return schema
+
+
 def generate(
     schema: dict,
     title: str = "jsonschema-markdown",
@@ -119,6 +209,8 @@ def generate(
         _schema: dict = jsonref.replace_refs(schema)  # type: ignore
     else:
         _schema = schema
+
+    _schema = _extract_inline_defs(_schema)
     markdown = ""
 
     # Add the title and description of the schema

--- a/tests/schema-examples/multiple-anyof-inline.json
+++ b/tests/schema-examples/multiple-anyof-inline.json
@@ -1,0 +1,551 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "scene_time": {
+      "format": "date-time",
+      "title": "Scene Time",
+      "type": "string"
+    },
+    "cinema_event": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "director_verdict",
+              "default": "director_verdict",
+              "title": "Kind",
+              "type": "string"
+            },
+            "studio_lot": {
+              "title": "Studio Lot",
+              "type": "string"
+            },
+            "director_contact": {
+              "title": "Director Contact",
+              "type": "string"
+            },
+            "producer_contact": {
+              "title": "Producer Contact",
+              "type": "string"
+            },
+            "franchise": {
+              "title": "Franchise",
+              "type": "string"
+            },
+            "release_stage": {
+              "title": "Release Stage",
+              "type": "string"
+            },
+            "verdict": {
+              "title": "Verdict",
+              "type": "string"
+            },
+            "reel_code": {
+              "title": "Reel Code",
+              "type": "string"
+            },
+            "screening_id": {
+              "title": "Screening Id",
+              "type": "string"
+            },
+            "character_arc": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Character Arc"
+            },
+            "cut_style": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Cut Style"
+            }
+          },
+          "required": [
+            "studio_lot",
+            "director_contact",
+            "producer_contact",
+            "franchise",
+            "release_stage",
+            "verdict",
+            "reel_code",
+            "screening_id"
+          ],
+          "title": "DirectorVerdict",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "prop_vault_action",
+              "default": "prop_vault_action",
+              "title": "Kind",
+              "type": "string"
+            },
+            "crew_member": {
+              "title": "Crew Member",
+              "type": "string"
+            },
+            "prop_name": {
+              "title": "Prop Name",
+              "type": "string"
+            },
+            "studio_lot": {
+              "title": "Studio Lot",
+              "type": "string"
+            },
+            "franchise": {
+              "title": "Franchise",
+              "type": "string"
+            },
+            "release_stage": {
+              "title": "Release Stage",
+              "type": "string"
+            },
+            "action": {
+              "title": "Action",
+              "type": "string"
+            }
+          },
+          "required": [
+            "crew_member",
+            "prop_name",
+            "studio_lot",
+            "franchise",
+            "release_stage",
+            "action"
+          ],
+          "title": "PropVaultAction",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "casting_slot_action",
+              "default": "casting_slot_action",
+              "title": "Kind",
+              "type": "string"
+            },
+            "final_notes": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "contact": {
+                      "title": "Contact",
+                      "type": "string"
+                    },
+                    "stage_name": {
+                      "title": "Stage Name",
+                      "type": "string"
+                    },
+                    "mark_ms": {
+                      "title": "Mark Ms",
+                      "type": "integer"
+                    },
+                    "commentary": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null,
+                      "title": "Commentary"
+                    }
+                  },
+                  "required": [
+                    "contact",
+                    "stage_name",
+                    "mark_ms"
+                  ],
+                  "title": "Credit",
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "character_arc": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Character Arc"
+            },
+            "production_meta": {
+              "anyOf": [
+                {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Production Meta"
+            },
+            "audition_notes": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "contact": {
+                      "title": "Contact",
+                      "type": "string"
+                    },
+                    "stage_name": {
+                      "title": "Stage Name",
+                      "type": "string"
+                    },
+                    "mark_ms": {
+                      "title": "Mark Ms",
+                      "type": "integer"
+                    },
+                    "commentary": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null,
+                      "title": "Commentary"
+                    }
+                  },
+                  "required": [
+                    "contact",
+                    "stage_name",
+                    "mark_ms"
+                  ],
+                  "title": "Credit",
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "casting_lane": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "ensemble",
+                    "lead",
+                    "franchise"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Casting Lane"
+            },
+            "phase_state": {
+              "title": "Phase State",
+              "type": "string"
+            }
+          },
+          "required": [
+            "phase_state"
+          ],
+          "title": "CastingSlotAction",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "set_renaming",
+              "default": "set_renaming",
+              "title": "Kind",
+              "type": "string"
+            },
+            "old_set": {
+              "title": "Old Set",
+              "type": "string"
+            },
+            "new_set": {
+              "title": "New Set",
+              "type": "string"
+            },
+            "release_stage": {
+              "title": "Release Stage",
+              "type": "string"
+            },
+            "franchise": {
+              "title": "Franchise",
+              "type": "string"
+            },
+            "reel_code": {
+              "title": "Reel Code",
+              "type": "string"
+            },
+            "studio_project_id": {
+              "title": "Studio Project Id",
+              "type": "string"
+            },
+            "screening_id": {
+              "title": "Screening Id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "old_set",
+            "new_set",
+            "release_stage",
+            "franchise",
+            "reel_code",
+            "studio_project_id",
+            "screening_id"
+          ],
+          "title": "SetRenaming",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "box_office_action",
+              "default": "box_office_action",
+              "title": "Kind",
+              "type": "string"
+            },
+            "analyst": {
+              "title": "Analyst",
+              "type": "string"
+            },
+            "franchise": {
+              "title": "Franchise",
+              "type": "string"
+            },
+            "prior_gross": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Prior Gross"
+            },
+            "updated_gross": {
+              "title": "Updated Gross",
+              "type": "number"
+            },
+            "action": {
+              "title": "Action",
+              "type": "string"
+            },
+            "market": {
+              "title": "Market",
+              "type": "string"
+            }
+          },
+          "required": [
+            "analyst",
+            "franchise",
+            "updated_gross",
+            "action",
+            "market"
+          ],
+          "title": "BoxOfficeAction",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "premiere_event",
+              "default": "premiere_event",
+              "title": "Kind",
+              "type": "string"
+            },
+            "event_kind": {
+              "enum": [
+                "shoot_started",
+                "shoot_paused",
+                "shoot_resumed",
+                "shoot_wrapped",
+                "shoot_failed"
+              ],
+              "title": "Event Kind",
+              "type": "string"
+            },
+            "release_stage": {
+              "title": "Release Stage",
+              "type": "string"
+            },
+            "franchise": {
+              "title": "Franchise",
+              "type": "string"
+            },
+            "reel_code": {
+              "title": "Reel Code",
+              "type": "string"
+            },
+            "screening_id": {
+              "title": "Screening Id",
+              "type": "string"
+            },
+            "festival_id": {
+              "title": "Festival Id",
+              "type": "string"
+            },
+            "scene_hash": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Scene Hash"
+            },
+            "studio_project_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Studio Project Id"
+            }
+          },
+          "required": [
+            "event_kind",
+            "release_stage",
+            "franchise",
+            "reel_code",
+            "screening_id",
+            "festival_id"
+          ],
+          "title": "PremiereEvent",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "crew_event",
+              "default": "crew_event",
+              "title": "Kind",
+              "type": "string"
+            },
+            "event_kind": {
+              "enum": [
+                "crew_called",
+                "crew_wrapped",
+                "crew_issue"
+              ],
+              "title": "Event Kind",
+              "type": "string"
+            },
+            "release_stage": {
+              "title": "Release Stage",
+              "type": "string"
+            },
+            "franchise": {
+              "title": "Franchise",
+              "type": "string"
+            },
+            "screening_id": {
+              "title": "Screening Id",
+              "type": "string"
+            },
+            "crew_unit": {
+              "title": "Crew Unit",
+              "type": "string"
+            },
+            "act": {
+              "title": "Act",
+              "type": "string"
+            },
+            "reel_code": {
+              "title": "Reel Code",
+              "type": "string"
+            },
+            "outcome": {
+              "anyOf": [
+                {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Outcome"
+            }
+          },
+          "required": [
+            "event_kind",
+            "release_stage",
+            "franchise",
+            "screening_id",
+            "crew_unit",
+            "act",
+            "reel_code",
+            "outcome"
+          ],
+          "title": "CrewEvent",
+          "type": "object"
+        }
+      ],
+      "title": "Cinema Event"
+    }
+  },
+  "required": [
+    "scene_time",
+    "cinema_event"
+  ],
+  "title": "StudioAudit",
+  "type": "object"
+}

--- a/tests/schema-examples/multiple-anyof-inline.md
+++ b/tests/schema-examples/multiple-anyof-inline.md
@@ -1,0 +1,170 @@
+# StudioAudit
+
+JSON Schema missing a description, provide it using the `description` key in the root of the JSON document.
+
+### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
+
+| Property | Type | Required | Possible values | Deprecated | Default | Description | Examples |
+| -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- | -------- |
+| scene_time | `string` | ✅ | Format: [`date-time`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |  |  |  |
+| cinema_event | `object` | ✅ | [BoxOfficeAction](#boxofficeaction) and/or [CastingSlotAction](#castingslotaction) and/or [CrewEvent](#crewevent) and/or [DirectorVerdict](#directorverdict) and/or [PremiereEvent](#premiereevent) and/or [PropVaultAction](#propvaultaction) and/or [SetRenaming](#setrenaming) |  |  |  |  |
+
+
+---
+
+# Definitions
+
+## DirectorVerdict
+
+No description provided for this model.
+
+#### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
+
+| Property | Type | Required | Possible values | Deprecated | Default | Description | Examples |
+| -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- | -------- |
+| studio_lot | `string` | ✅ | string |  |  |  |  |
+| director_contact | `string` | ✅ | string |  |  |  |  |
+| producer_contact | `string` | ✅ | string |  |  |  |  |
+| franchise | `string` | ✅ | string |  |  |  |  |
+| release_stage | `string` | ✅ | string |  |  |  |  |
+| verdict | `string` | ✅ | string |  |  |  |  |
+| reel_code | `string` | ✅ | string |  |  |  |  |
+| screening_id | `string` | ✅ | string |  |  |  |  |
+| kind | `const` |  | `director_verdict` |  | `"director_verdict"` |  |  |
+| character_arc | `string` or `null` |  | string |  | `null` |  |  |
+| cut_style | `string` or `null` |  | string |  | `null` |  |  |
+
+## PropVaultAction
+
+No description provided for this model.
+
+#### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
+
+| Property | Type | Required | Possible values | Deprecated | Default | Description | Examples |
+| -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- | -------- |
+| crew_member | `string` | ✅ | string |  |  |  |  |
+| prop_name | `string` | ✅ | string |  |  |  |  |
+| studio_lot | `string` | ✅ | string |  |  |  |  |
+| franchise | `string` | ✅ | string |  |  |  |  |
+| release_stage | `string` | ✅ | string |  |  |  |  |
+| action | `string` | ✅ | string |  |  |  |  |
+| kind | `const` |  | `prop_vault_action` |  | `"prop_vault_action"` |  |  |
+
+## Credit
+
+No description provided for this model.
+
+#### Type: `object`
+
+| Property | Type | Required | Possible values | Deprecated | Default | Description | Examples |
+| -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- | -------- |
+| contact | `string` | ✅ | string |  |  |  |  |
+| stage_name | `string` | ✅ | string |  |  |  |  |
+| mark_ms | `integer` | ✅ | integer |  |  |  |  |
+| commentary | `string` or `null` |  | string |  | `null` |  |  |
+
+## CastingSlotAction
+
+No description provided for this model.
+
+#### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
+
+| Property | Type | Required | Possible values | Deprecated | Default | Description | Examples |
+| -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- | -------- |
+| phase_state | `string` | ✅ | string |  |  |  |  |
+| kind | `const` |  | `casting_slot_action` |  | `"casting_slot_action"` |  |  |
+| final_notes | `object` or `null` |  | [Credit](#credit) |  | `null` |  |  |
+| character_arc | `string` or `null` |  | string |  | `null` |  |  |
+| production_meta | `object` or `null` |  | object |  | `null` |  |  |
+| audition_notes | `object` or `null` |  | [Credit](#credit) |  | `null` |  |  |
+| casting_lane | `string` or `null` |  | `ensemble` `lead` `franchise` |  | `null` |  |  |
+
+## SetRenaming
+
+No description provided for this model.
+
+#### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
+
+| Property | Type | Required | Possible values | Deprecated | Default | Description | Examples |
+| -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- | -------- |
+| old_set | `string` | ✅ | string |  |  |  |  |
+| new_set | `string` | ✅ | string |  |  |  |  |
+| release_stage | `string` | ✅ | string |  |  |  |  |
+| franchise | `string` | ✅ | string |  |  |  |  |
+| reel_code | `string` | ✅ | string |  |  |  |  |
+| studio_project_id | `string` | ✅ | string |  |  |  |  |
+| screening_id | `string` | ✅ | string |  |  |  |  |
+| kind | `const` |  | `set_renaming` |  | `"set_renaming"` |  |  |
+
+## BoxOfficeAction
+
+No description provided for this model.
+
+#### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
+
+| Property | Type | Required | Possible values | Deprecated | Default | Description | Examples |
+| -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- | -------- |
+| analyst | `string` | ✅ | string |  |  |  |  |
+| franchise | `string` | ✅ | string |  |  |  |  |
+| updated_gross | `number` | ✅ | number |  |  |  |  |
+| action | `string` | ✅ | string |  |  |  |  |
+| market | `string` | ✅ | string |  |  |  |  |
+| kind | `const` |  | `box_office_action` |  | `"box_office_action"` |  |  |
+| prior_gross | `number` or `null` |  | number |  | `null` |  |  |
+
+## PremiereEvent
+
+No description provided for this model.
+
+#### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
+
+| Property | Type | Required | Possible values | Deprecated | Default | Description | Examples |
+| -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- | -------- |
+| event_kind | `string` | ✅ | `shoot_started` `shoot_paused` `shoot_resumed` `shoot_wrapped` `shoot_failed` |  |  |  |  |
+| release_stage | `string` | ✅ | string |  |  |  |  |
+| franchise | `string` | ✅ | string |  |  |  |  |
+| reel_code | `string` | ✅ | string |  |  |  |  |
+| screening_id | `string` | ✅ | string |  |  |  |  |
+| festival_id | `string` | ✅ | string |  |  |  |  |
+| kind | `const` |  | `premiere_event` |  | `"premiere_event"` |  |  |
+| scene_hash | `string` or `null` |  | string |  | `null` |  |  |
+| studio_project_id | `string` or `null` |  | string |  | `null` |  |  |
+
+## CrewEvent
+
+No description provided for this model.
+
+#### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
+
+| Property | Type | Required | Possible values | Deprecated | Default | Description | Examples |
+| -------- | ---- | -------- | --------------- | ---------- | ------- | ----------- | -------- |
+| event_kind | `string` | ✅ | `crew_called` `crew_wrapped` `crew_issue` |  |  |  |  |
+| release_stage | `string` | ✅ | string |  |  |  |  |
+| franchise | `string` | ✅ | string |  |  |  |  |
+| screening_id | `string` | ✅ | string |  |  |  |  |
+| crew_unit | `string` | ✅ | string |  |  |  |  |
+| act | `string` | ✅ | string |  |  |  |  |
+| reel_code | `string` | ✅ | string |  |  |  |  |
+| outcome | `object` or `null` | ✅ | object |  |  |  |  |
+| kind | `const` |  | `crew_event` |  | `"crew_event"` |  |  |
+
+
+---
+
+Markdown generated with [jsonschema-markdown](https://github.com/elisiariocouto/jsonschema-markdown).

--- a/tests/schema-examples/multiple-anyof-inline_no-empty-columns.md
+++ b/tests/schema-examples/multiple-anyof-inline_no-empty-columns.md
@@ -1,0 +1,170 @@
+# StudioAudit
+
+JSON Schema missing a description, provide it using the `description` key in the root of the JSON document.
+
+### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
+
+| Property | Type | Required | Possible values | Description |
+| -------- | ---- | -------- | --------------- | ----------- |
+| scene_time | `string` | ✅ | Format: [`date-time`](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) |  |
+| cinema_event | `object` | ✅ | [BoxOfficeAction](#boxofficeaction) and/or [CastingSlotAction](#castingslotaction) and/or [CrewEvent](#crewevent) and/or [DirectorVerdict](#directorverdict) and/or [PremiereEvent](#premiereevent) and/or [PropVaultAction](#propvaultaction) and/or [SetRenaming](#setrenaming) |  |
+
+
+---
+
+# Definitions
+
+## DirectorVerdict
+
+No description provided for this model.
+
+#### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| studio_lot | `string` | ✅ | string |  |  |
+| director_contact | `string` | ✅ | string |  |  |
+| producer_contact | `string` | ✅ | string |  |  |
+| franchise | `string` | ✅ | string |  |  |
+| release_stage | `string` | ✅ | string |  |  |
+| verdict | `string` | ✅ | string |  |  |
+| reel_code | `string` | ✅ | string |  |  |
+| screening_id | `string` | ✅ | string |  |  |
+| kind | `const` |  | `director_verdict` | `"director_verdict"` |  |
+| character_arc | `string` or `null` |  | string | `null` |  |
+| cut_style | `string` or `null` |  | string | `null` |  |
+
+## PropVaultAction
+
+No description provided for this model.
+
+#### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| crew_member | `string` | ✅ | string |  |  |
+| prop_name | `string` | ✅ | string |  |  |
+| studio_lot | `string` | ✅ | string |  |  |
+| franchise | `string` | ✅ | string |  |  |
+| release_stage | `string` | ✅ | string |  |  |
+| action | `string` | ✅ | string |  |  |
+| kind | `const` |  | `prop_vault_action` | `"prop_vault_action"` |  |
+
+## Credit
+
+No description provided for this model.
+
+#### Type: `object`
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| contact | `string` | ✅ | string |  |  |
+| stage_name | `string` | ✅ | string |  |  |
+| mark_ms | `integer` | ✅ | integer |  |  |
+| commentary | `string` or `null` |  | string | `null` |  |
+
+## CastingSlotAction
+
+No description provided for this model.
+
+#### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| phase_state | `string` | ✅ | string |  |  |
+| kind | `const` |  | `casting_slot_action` | `"casting_slot_action"` |  |
+| final_notes | `object` or `null` |  | [Credit](#credit) | `null` |  |
+| character_arc | `string` or `null` |  | string | `null` |  |
+| production_meta | `object` or `null` |  | object | `null` |  |
+| audition_notes | `object` or `null` |  | [Credit](#credit) | `null` |  |
+| casting_lane | `string` or `null` |  | `ensemble` `lead` `franchise` | `null` |  |
+
+## SetRenaming
+
+No description provided for this model.
+
+#### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| old_set | `string` | ✅ | string |  |  |
+| new_set | `string` | ✅ | string |  |  |
+| release_stage | `string` | ✅ | string |  |  |
+| franchise | `string` | ✅ | string |  |  |
+| reel_code | `string` | ✅ | string |  |  |
+| studio_project_id | `string` | ✅ | string |  |  |
+| screening_id | `string` | ✅ | string |  |  |
+| kind | `const` |  | `set_renaming` | `"set_renaming"` |  |
+
+## BoxOfficeAction
+
+No description provided for this model.
+
+#### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| analyst | `string` | ✅ | string |  |  |
+| franchise | `string` | ✅ | string |  |  |
+| updated_gross | `number` | ✅ | number |  |  |
+| action | `string` | ✅ | string |  |  |
+| market | `string` | ✅ | string |  |  |
+| kind | `const` |  | `box_office_action` | `"box_office_action"` |  |
+| prior_gross | `number` or `null` |  | number | `null` |  |
+
+## PremiereEvent
+
+No description provided for this model.
+
+#### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| event_kind | `string` | ✅ | `shoot_started` `shoot_paused` `shoot_resumed` `shoot_wrapped` `shoot_failed` |  |  |
+| release_stage | `string` | ✅ | string |  |  |
+| franchise | `string` | ✅ | string |  |  |
+| reel_code | `string` | ✅ | string |  |  |
+| screening_id | `string` | ✅ | string |  |  |
+| festival_id | `string` | ✅ | string |  |  |
+| kind | `const` |  | `premiere_event` | `"premiere_event"` |  |
+| scene_hash | `string` or `null` |  | string | `null` |  |
+| studio_project_id | `string` or `null` |  | string | `null` |  |
+
+## CrewEvent
+
+No description provided for this model.
+
+#### Type: `object`
+
+> ⚠️ Additional properties are not allowed.
+
+| Property | Type | Required | Possible values | Default | Description |
+| -------- | ---- | -------- | --------------- | ------- | ----------- |
+| event_kind | `string` | ✅ | `crew_called` `crew_wrapped` `crew_issue` |  |  |
+| release_stage | `string` | ✅ | string |  |  |
+| franchise | `string` | ✅ | string |  |  |
+| screening_id | `string` | ✅ | string |  |  |
+| crew_unit | `string` | ✅ | string |  |  |
+| act | `string` | ✅ | string |  |  |
+| reel_code | `string` | ✅ | string |  |  |
+| outcome | `object` or `null` | ✅ | object |  |  |
+| kind | `const` |  | `crew_event` | `"crew_event"` |  |
+
+
+---
+
+Markdown generated with [jsonschema-markdown](https://github.com/elisiariocouto/jsonschema-markdown).


### PR DESCRIPTION
## Summary

- When schemas use inline objects in `anyOf`/`oneOf`/`allOf` instead of `$ref`, the markdown output was unreadable (e.g. `object and/or object and/or object and/or ...`)
- Added a `_extract_inline_defs()` preprocessing step that walks the schema tree, extracts inline objects into synthetic `$defs` entries, and replaces them with `$ref` pointers
- The existing rendering code handles `$ref` + `$defs` already, so no rendering logic changes were needed
- Handles deduplication (identical inline objects like "Credit" appearing multiple times), nested inline objects, title collisions, and untitled objects

## Test plan

- [x] All 52 existing tests pass with no regressions
- [x] New test schema `multiple-anyof-inline.json` with 7 inline anyOf objects + nested inline objects
- [x] Verified `cinema_event` renders as `[DirectorVerdict](#directorverdict) and/or ...` with clickable definition links
- [x] Verified Definitions section renders full property tables for all extracted types
- [x] Verified deduplication: "Credit" object appears twice in schema but only once in definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)