### PR TITLE
Use explicit utf-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ The Docker image is available at:
 
 ## Usage as a library
 
-To use it as a library, load your JSON schema file as Python `dict` and pass it to generate.
+To use it as a library, load your JSON schema file as Python `dict` and pass it to `generate`.
 The function will return a string with the markdown.
 
 ```python
 import jsonschema_markdown
 
-with open('schema.json') as f:
+with open('schema.json', 'r', encoding='utf-8') as f:
     schema = json.load(f)
 
 markdown = jsonschema_markdown.generate(schema)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -6,7 +6,7 @@ def test_generate():
     schema = Car.model_json_schema()
     markdown = generate(schema)
 
-    with open("tests/model.md", "r") as f:
+    with open("tests/model.md", "r", encoding="utf-8") as f:
         expected_markdown = f.read()
 
     assert markdown == expected_markdown
@@ -16,7 +16,7 @@ def test_generate_hide_empty_columns():
     schema = Car.model_json_schema()
     markdown = generate(schema, hide_empty_columns=True)
 
-    with open("tests/model_no-empty-columns.md", "r") as f:
+    with open("tests/model_no-empty-columns.md", "r", encoding="utf-8") as f:
         expected_markdown = f.read()
 
     assert markdown == expected_markdown
@@ -26,7 +26,7 @@ def test_generate_custom_title_no_footer():
     schema = Car.model_json_schema()
     markdown = generate(schema, title="Car (custom title)", footer=False)
 
-    with open("tests/model_custom-title_no-footer.md", "r") as f:
+    with open("tests/model_custom-title_no-footer.md", "r", encoding="utf-8") as f:
         expected_markdown = f.read()
 
     assert markdown == expected_markdown

--- a/tests/test_schema_examples.py
+++ b/tests/test_schema_examples.py
@@ -32,10 +32,10 @@ def get_test_cases():
 
 @pytest.mark.parametrize("json_path, md_path, kwargs", get_test_cases())
 def test_schema_examples(json_path, md_path, kwargs):
-    with open(json_path, "r") as f:
+    with open(json_path, "r", encoding="utf-8") as f:
         schema = json.load(f)
 
-    with open(md_path, "r") as f:
+    with open(md_path, "r", encoding="utf-8") as f:
         expected_markdown = f.read()
 
     markdown = jsonschema_markdown.generate(schema, **kwargs)


### PR DESCRIPTION
Thanks again for this!

I've started looking a bit at packaging this for [`conda-forge`](https://github.com/conda-forge/staged-recipes/pull/34528), where one of the gates is "works on windows."

This PR uses an explicitly declared `encoding="utf-8"` in various places, which will become a hard requirement in some future version of Python (though unclear exactly _when_ from [PEP-597](https://peps.python.org/pep-0597))

A more thorough test would of course be to add Windows to the CI matrix, which might be reasonable either on this PR or as a follow on, at your preference.